### PR TITLE
Update hardware-specification.mdx

### DIFF
--- a/content/docs/hardware-specification.mdx
+++ b/content/docs/hardware-specification.mdx
@@ -12,7 +12,7 @@ Keycard applet runs on any JavaCard 3.0.4+ (see [applet installation](/docs/gett
 We use for manufacturing:
 - **model:** NXP JCOP4
 - **interfaces:** NFC, ISO7816
-- **EAL5+ certified**
+- **EAL6+ certified**
 
 ## Keycard Shell
 


### PR DESCRIPTION
It should be EAL6+ instead of EAL5+ on https://keycard.tech/docs/hardware-specification