### PR TITLE
Update homepage hero copy and buy CTAs

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -145,15 +145,15 @@
       "notes": "hero::keycard_shell_title"
     },
     "keycard_shell_subtitle": {
-      "translation": "Ein sicheres Gerät,\nunendlich viele Backups",
+      "translation": "Die Hardware-Wallet,\ndie nichts zu verbergen hat",
       "notes": "hero::keycard_shell_subtitle"
     },
     "keycard_shell_description": {
-      "translation": "Unübertroffene Sicherheit mit einer unbegrenzten Anzahl austauschbarer Keycards, jede mit ihrem eigenen Schlüssel.",
+      "translation": "Vollständig quelloffene Hardware und Software. Air-gapped QR-Signierung mit mehr als 15 kompatiblen Wallets. Ihre Schlüssel liegen auf Smartcards und bleiben unter Ihrer Kontrolle.",
       "notes": "hero::keycard_shell_description"
     },
     "discover_shell": {
-      "translation": "Shell entdecken",
+      "translation": "Shell kaufen",
       "notes": "hero::discover_shell"
     },
     "keycard_title": {
@@ -169,7 +169,7 @@
       "notes": "hero::keycard_description"
     },
     "discover_keycard": {
-      "translation": "Keycard entdecken",
+      "translation": "Keycard kaufen",
       "notes": "hero::discover_keycard"
     }
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -131,15 +131,15 @@
       "notes": "hero::keycard_shell_title"
     },
     "keycard_shell_subtitle": {
-      "translation": "One secure device,\ninfinite backups",
+      "translation": "The hardware wallet\nwhich has nothing to hide",
       "notes": "hero::keycard_shell_subtitle"
     },
     "keycard_shell_description": {
-      "translation": "Unrivalled security with an infinite number of removable Keycards, each with their own key.",
+      "translation": "Fully open source hardware and software. Air-gapped QR signing with 15+ compatible wallets. Your keys live on smartcards and remain under your control.",
       "notes": "hero::keycard_shell_description"
     },
     "discover_shell": {
-      "translation": "Discover Shell",
+      "translation": "Buy Shell",
       "notes": "hero::discover_shell"
     },
     "keycard_title": {
@@ -155,7 +155,7 @@
       "notes": "hero::keycard_description"
     },
     "discover_keycard": {
-      "translation": "Discover Keycard",
+      "translation": "Buy Keycard",
       "notes": "hero::discover_keycard"
     }
   },

--- a/messages/es.json
+++ b/messages/es.json
@@ -145,15 +145,15 @@
       "notes": "hero::keycard_shell_title"
     },
     "keycard_shell_subtitle": {
-      "translation": "Un dispositivo seguro,\ncopias de seguridad infinitas",
+      "translation": "La hardware wallet\nque no tiene nada que ocultar",
       "notes": "hero::keycard_shell_subtitle"
     },
     "keycard_shell_description": {
-      "translation": "Seguridad inigualable con un número infinito de Keycards extraíbles, cada una con su propia clave.",
+      "translation": "Hardware y software totalmente de código abierto. Firma por QR air-gapped con más de 15 wallets compatibles. Tus claves viven en smartcards y permanecen bajo tu control.",
       "notes": "hero::keycard_shell_description"
     },
     "discover_shell": {
-      "translation": "Descubrir Shell",
+      "translation": "Comprar Shell",
       "notes": "hero::discover_shell"
     },
     "keycard_title": {
@@ -169,7 +169,7 @@
       "notes": "hero::keycard_description"
     },
     "discover_keycard": {
-      "translation": "Descubrir Keycard",
+      "translation": "Comprar Keycard",
       "notes": "hero::discover_keycard"
     }
   },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -145,15 +145,15 @@
       "notes": "hero::keycard_shell_title"
     },
     "keycard_shell_subtitle": {
-      "translation": "Un appareil sécurisé,\nune infinité de sauvegardes",
+      "translation": "Le hardware wallet\nqui n’a rien à cacher",
       "notes": "hero::keycard_shell_subtitle"
     },
     "keycard_shell_description": {
-      "translation": "Une sécurité inégalée avec un nombre infini de Keycards amovibles, chacune avec sa propre clé.",
+      "translation": "Hardware et software entièrement open source. Signature QR air-gapped avec plus de 15 wallets compatibles. Vos clés vivent sur des smartcards et restent sous votre contrôle.",
       "notes": "hero::keycard_shell_description"
     },
     "discover_shell": {
-      "translation": "Découvrir Shell",
+      "translation": "Acheter Shell",
       "notes": "hero::discover_shell"
     },
     "keycard_title": {
@@ -169,7 +169,7 @@
       "notes": "hero::keycard_description"
     },
     "discover_keycard": {
-      "translation": "Découvrir Keycard",
+      "translation": "Acheter Keycard",
       "notes": "hero::discover_keycard"
     }
   },

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -145,15 +145,15 @@
       "notes": "hero::keycard_shell_title"
     },
     "keycard_shell_subtitle": {
-      "translation": "하나의 안전한 기기,\n무한한 백업",
+      "translation": "숨길 것이 없는\n하드웨어 월렛",
       "notes": "hero::keycard_shell_subtitle"
     },
     "keycard_shell_description": {
-      "translation": "각각 고유한 키를 가진 무한한 수의 제거 가능한 Keycard로 비교할 수 없는 보안을 제공합니다.",
+      "translation": "하드웨어와 소프트웨어가 모두 완전 오픈소스입니다. 15개 이상의 호환 월렛에서 에어갭 QR 서명을 지원합니다. 키는 스마트카드에 저장되며 언제나 사용자의 통제 아래 있습니다.",
       "notes": "hero::keycard_shell_description"
     },
     "discover_shell": {
-      "translation": "Shell 발견하기",
+      "translation": "Shell 구매하기",
       "notes": "hero::discover_shell"
     },
     "keycard_title": {
@@ -169,7 +169,7 @@
       "notes": "hero::keycard_description"
     },
     "discover_keycard": {
-      "translation": "Keycard 발견하기",
+      "translation": "Keycard 구매하기",
       "notes": "hero::discover_keycard"
     }
   },

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -145,15 +145,15 @@
       "notes": "hero::keycard_shell_title"
     },
     "keycard_shell_subtitle": {
-      "translation": "Eén veilig apparaat,\nonceindig veel back-ups",
+      "translation": "De hardware wallet\ndie niets te verbergen heeft",
       "notes": "hero::keycard_shell_subtitle"
     },
     "keycard_shell_description": {
-      "translation": "Ongeëvenaarde beveiliging met een onbeperkt aantal verwijderbare Keycards, elk met zijn eigen sleutel.",
+      "translation": "Volledig open-source hardware en software. Air-gapped QR-ondertekening met 15+ compatibele wallets. Je sleutels leven op smartcards en blijven onder jouw controle.",
       "notes": "hero::keycard_shell_description"
     },
     "discover_shell": {
-      "translation": "Shell ontdekken",
+      "translation": "Shell kopen",
       "notes": "hero::discover_shell"
     },
     "keycard_title": {
@@ -169,7 +169,7 @@
       "notes": "hero::keycard_description"
     },
     "discover_keycard": {
-      "translation": "Keycard ontdekken",
+      "translation": "Keycard kopen",
       "notes": "hero::discover_keycard"
     }
   },


### PR DESCRIPTION
## Summary
- Update Keycard Shell hero headline to: "The hardware wallet which has nothing to hide"
- Update Keycard Shell sub-hero description with open-source, air-gapped QR signing, and smartcard custody messaging
- Change hero action labels from "Discover Shell/Keycard" to "Buy Shell/Keycard"

## Notes
- Changes are limited to English copy in `messages/en.json`.