### PR TITLE
Align homepage H1/H2 with visible hero headings

### DIFF
--- a/src/app/[locale]/(with-navigation)/(homepage)/_components/keycard-shell.tsx
+++ b/src/app/[locale]/(with-navigation)/(homepage)/_components/keycard-shell.tsx
@@ -51,13 +51,10 @@ const KeycardShell = () => {
       </motion.div>
 
       <div className="relative z-10 flex max-w-[434px] flex-col px-5 py-6 lg:ml-[72px] lg:p-0">
-        <h2 className="sr-only">
-          Keycard Shell - Modular, Air-Gapped Hardware Wallet
-        </h2>
         <p className="pb-2 text-24 font-600 text-white-95">
           {t('hero.keycard_shell_title.translation')}
         </p>
-        <p className="pb-8 font-lora text-32 font-400 lg:pb-4 lg:text-48">
+        <h1 className="pb-8 font-lora text-32 font-400 lg:pb-4 lg:text-48">
           {t('hero.keycard_shell_subtitle.translation')
             .split('\n')
             .map((line, index) => (
@@ -66,7 +63,7 @@ const KeycardShell = () => {
                 {index === 0 && <br />}
               </span>
             ))}
-        </p>
+        </h1>
         <p className="pb-8 text-20 font-300 text-white-80">
           {t('hero.keycard_shell_description.translation')}
         </p>

--- a/src/app/[locale]/(with-navigation)/(homepage)/page.tsx
+++ b/src/app/[locale]/(with-navigation)/(homepage)/page.tsx
@@ -31,9 +31,6 @@ export async function generateMetadata({ params }: MetadataProps) {
 export default function HomePage() {
   return (
     <>
-      <h1 className="sr-only">
-        Keycard — Modular, Open-Source Crypto Hardware
-      </h1>
       <AutoOpenDialogManager />
       <KeycardShell />
       <Keycard />


### PR DESCRIPTION
## Summary
- Replace the visible Keycard Shell hero subtitle wrapper from `p` to `h1`
- Remove hidden/sr-only homepage `h1` and hidden/sr-only Shell `h2`
- Keep heading structure aligned with what users actually see on the page

## Context
This follows the merged copy/translation changes and only addresses semantic heading alignment.