### PR TITLE
Set Shell sub-hero as homepage H2

### DIFF
--- a/src/app/[locale]/(with-navigation)/(homepage)/_components/keycard-shell.tsx
+++ b/src/app/[locale]/(with-navigation)/(homepage)/_components/keycard-shell.tsx
@@ -64,9 +64,9 @@ const KeycardShell = () => {
               </span>
             ))}
         </h1>
-        <p className="pb-8 text-20 font-300 text-white-80">
+        <h2 className="pb-8 text-20 font-300 text-white-80">
           {t('hero.keycard_shell_description.translation')}
-        </p>
+        </h2>
         <div className="flex gap-4">
           <ButtonLink
             href={shellUrl}


### PR DESCRIPTION
## Summary
- Change the Shell sub-hero description element from `p` to `h2`
- Keep the existing copy unchanged
- Align homepage heading semantics with the requested H1/H2 structure