### PR TITLE
Update React Native library repository link

### DIFF
--- a/content/developers/github-repositories.mdx
+++ b/content/developers/github-repositories.mdx
@@ -13,7 +13,7 @@ title: GitHub Repositories
 * [Go SDK](https://github.com/keycard-tech/keycard-go/)
 * [Swift SDK](https://github.com/keycard-tech/Keycard.swift)
 * [Keycard on Ledger](https://github.com/keycard-tech/keycard-ledger)
-* [React Native library](https://github.com/keycard-tech/react-native-status-keycard)
+* [React Native library](https://github.com/choppu/react-native-keycard)
 * [Go Status library](https://github.com/keycard-tech/status-keycard-go)
 * [Python SDK](https://github.com/mmlado/keycard-py) by mmlado
 * [Typescript SDK](https://github.com/choppu/keycard-sdk) by choppu


### PR DESCRIPTION
## Summary
- update the React Native library entry on the developers GitHub repositories page
- replace the old `keycard-tech/react-native-status-keycard` URL with `choppu/react-native-keycard`

## Test plan
- [x] Confirm the updated link is present in `content/developers/github-repositories.mdx`
- [x] Verify markdown formatting remains valid after the change