### PR TITLE
Migrate likely docs links to docs.keycard.tech

### DIFF
--- a/content/help/about-keycard-and-keycard-shell.mdx
+++ b/content/help/about-keycard-and-keycard-shell.mdx
@@ -31,7 +31,7 @@ Shell must work with Keycard. You can share your Shell with others because it do
 
 Key features:
 - **Display**: Review transaction details on screen
-- **Wide wallet support**: MetaMask, Rabby, imToken, Sparrow, BlueWallet [and more](https://keycard.tech/wallets)
+- **Wide wallet support**: MetaMask, Rabby, imToken, Sparrow, BlueWallet [and more](https://docs.keycard.tech/wallets)
 - **Air-gapped operation**: [Sign transactions](./sign-a-transaction-using-keycard-shell) via QR codes
 - **SLIP39 support**: [Generate and restore wallets](./set-up-your-keycard-with-keycard-shell#step-2-add-a-master-key-pair) with SLIP39
 - **Keycard management**: [Change PIN](./change-your-keycard-pin-or-duress-pin), [unblock](./unblock-your-keycard-using-keycard-shell), and [factory reset](./factory-reset-your-keycard-using-keycard-shell)

--- a/content/help/change-pairing-password.mdx
+++ b/content/help/change-pairing-password.mdx
@@ -7,7 +7,7 @@ title: Change pairing password
 
 This is for advanced users only.
 
-Each Keycard has a pairing password for setting up a secure channel with a host. Most users never need to change it from the default value (see [core concepts](https://keycard.tech/en/developers/core)).
+Each Keycard has a pairing password for setting up a secure channel with a host. Most users never need to change it from the default value (see [core concepts](https://docs.keycard.tech/en/developers/core)).
 
 Change it if you're a developer or using Keycard with software that doesn't use the default value.
 

--- a/content/help/connect-keycard-shell-to-a-software-wallet.mdx
+++ b/content/help/connect-keycard-shell-to-a-software-wallet.mdx
@@ -7,10 +7,10 @@ title: Connect Keycard Shell to a software wallet
 
 ![Header image showing Keycard Shell alongside a software wallet on both a mobile phone and a computer.](/assets/docs/connect-keycard-shell-to-a-wallet-app-header.png)
 
-Keycard and Keycard Shell must work together with a software wallet that supports QR signing. After [setting up your Keycard](./set-up-your-keycard-with-keycard-shell), you need to connect your Keycard Shell to a [supported software wallet](https://keycard.tech/en/wallets). 
+Keycard and Keycard Shell must work together with a software wallet that supports QR signing. After [setting up your Keycard](./set-up-your-keycard-with-keycard-shell), you need to connect your Keycard Shell to a [supported software wallet](https://docs.keycard.tech/en/wallets). 
 
 <Admonition type="note">
-    Currently, Keycard Shell doesn't always appear on software wallet's list of supported hardware wallets, but you can still connect it to a [supported software wallet](https://keycard.tech/en/wallets) by selecting the **QR-based** (for example, MetaMask) or **Keystone** (for example, Rabby and Nunchuk) option.
+    Currently, Keycard Shell doesn't always appear on software wallet's list of supported hardware wallets, but you can still connect it to a [supported software wallet](https://docs.keycard.tech/en/wallets) by selecting the **QR-based** (for example, MetaMask) or **Keystone** (for example, Rabby and Nunchuk) option.
 </Admonition>
 
 ## What to expect

--- a/content/help/connect-keycard-shell-to-metamask.mdx
+++ b/content/help/connect-keycard-shell-to-metamask.mdx
@@ -17,7 +17,7 @@ You can use your Keycard Shell with MetaMask to manage crypto assets, interact w
 
 - After connecting to MetaMask, your wallet private keys remain on your Keycard, and MetaMask has no access to them.
 - MetaMask is an interface to manage your crypto assets. For any transactions generated during use, sign with Keycard Shell.
-- You can still connect your Keycard Shell to other [supported software wallets](https://keycard.tech/wallets).
+- You can still connect your Keycard Shell to other [supported software wallets](https://docs.keycard.tech/wallets).
 
 ## Connect Keycard Shell to MetaMask
 

--- a/content/help/connect-keycard-shell-to-sparrow-wallet.mdx
+++ b/content/help/connect-keycard-shell-to-sparrow-wallet.mdx
@@ -19,7 +19,7 @@ You can use your Keycard Shell with Sparrow Wallet to manage crypto assets, inte
 - If you have multiple Keycards, you can use each of them as separate cosigners in a multisig wallet.
 - After connecting to Sparrow, your wallet private keys remain on your Keycard, and Sparrow has no access to them.
 - Sparrow is an interface to manage your crypto assets. For any transactions generated during use, sign with Keycard Shell.
-- You can still connect your Keycard Shell to other [supported wallet apps](https://keycard.tech/wallets).
+- You can still connect your Keycard Shell to other [supported wallet apps](https://docs.keycard.tech/wallets).
 
 ## Import Keycard Bitcoin wallet to Sparrow
 

--- a/content/help/faq.mdx
+++ b/content/help/faq.mdx
@@ -41,9 +41,9 @@ No. The duress PIN unlocks a decoy wallet that uses the same recovery phrase and
 
 - **Can I use my Keycard or Keycard Shell without a software wallet?**
 
-No, you can't use your Keycard or Keycard Shell without a compatible software wallet. There are [10+ software wallet](https://keycard.tech/en/wallets) that you can use with Shell or Keycard. Software wallets are needed because they provide the interface for managing your crypto and creating your transactions, and they provide connection to the blockchain.
+No, you can't use your Keycard or Keycard Shell without a compatible software wallet. There are [10+ software wallet](https://docs.keycard.tech/en/wallets) that you can use with Shell or Keycard. Software wallets are needed because they provide the interface for managing your crypto and creating your transactions, and they provide connection to the blockchain.
 
-If you don't have a Shell or want to use Keycard by itself, you can use Keycard directly with [Status app ↗](https://status.app/help/keycard/create-a-status-wallet-account-using-a-keycard) or a software wallet which has integrated with Keycard (for instance [Sparrow](https://sparrowwallet.com/) for bitcoin). If you use Keycard and Keycard Shell together, there are [a list of options](https://keycard.tech/en/wallets) such as MetaMask, Rabby, or Sparrow.
+If you don't have a Shell or want to use Keycard by itself, you can use Keycard directly with [Status app ↗](https://status.app/help/keycard/create-a-status-wallet-account-using-a-keycard) or a software wallet which has integrated with Keycard (for instance [Sparrow](https://sparrowwallet.com/) for bitcoin). If you use Keycard and Keycard Shell together, there are [a list of options](https://docs.keycard.tech/en/wallets) such as MetaMask, Rabby, or Sparrow.
 
 - **Can I use more than one software wallet with the same Keycard Shell?**
 
@@ -85,6 +85,6 @@ To reset your Keycard PIN, [factory reset](./factory-reset-your-keycard-using-ke
 
 - **How do I get support if I have a problem with my Keycard or Keycard Shell?**
 
-If you need help with your Keycard or Keycard Shell, visit the [Help page](https://keycard.tech/en/help/about-keycard-and-keycard-shell) for guidance. 
+If you need help with your Keycard or Keycard Shell, visit the [Help page](https://docs.keycard.tech/en/help/about-keycard-and-keycard-shell) for guidance. 
 
 You can also ask questions in the [Keycard community](https://discord.gg/uJAXk7jFhZ) on Discord.

--- a/content/help/set-up-your-keycard-with-keycard-shell.mdx
+++ b/content/help/set-up-your-keycard-with-keycard-shell.mdx
@@ -7,7 +7,7 @@ title: Set up your Keycard with Keycard Shell
 
 ![Header image showing a Keycard inserted into a Keycard Shell.](/assets/docs/set-up-your-keycard-with-keycard-shell-header.png)
 
-You have two Keycard setup options: [using the Status app ↗](https://status.app/help/keycard/create-a-status-wallet-account-using-a-keycard), or using Keycard Shell. With Keycard Shell, you can connect your Keycard with other popular [software wallets](https://keycard.tech/en/wallets).
+You have two Keycard setup options: [using the Status app ↗](https://status.app/help/keycard/create-a-status-wallet-account-using-a-keycard), or using Keycard Shell. With Keycard Shell, you can connect your Keycard with other popular [software wallets](https://docs.keycard.tech/en/wallets).
 
 To use your Keycard with Keycard Shell, you need to set a Keycard PIN and optionally a duress PIN, then add a key pair to your Keycard.
 

--- a/content/help/sign-a-transaction-using-keycard-shell.mdx
+++ b/content/help/sign-a-transaction-using-keycard-shell.mdx
@@ -10,7 +10,7 @@ title: Sign a transaction using Keycard Shell
 Keycard and Keycard Shell work together with a software wallet that supports QR signing to initiate and sign transactions. You must [connect your Keycard Shell to a software wallet](./connect-keycard-shell-to-a-software-wallet) to initiate the transaction, then use your Keycard Shell to sign the transaction.
 
 <Admonition type="note">
-    For a list of supported software wallets, check out [Wallets compatible with Keycard and Shell](https://keycard.tech/en/wallets).
+    For a list of supported software wallets, check out [Wallets compatible with Keycard and Shell](https://docs.keycard.tech/en/wallets).
 </Admonition>
 
 ## What to expect

--- a/content/help/understand-the-slip-39-wallet-backup-standard.mdx
+++ b/content/help/understand-the-slip-39-wallet-backup-standard.mdx
@@ -72,7 +72,7 @@ When generating the recovery phrases, choose how many parts to create and the th
 When importing, enter one recovery phrase for each required part. For example, if your threshold is three, you enter any three sets of 20 words from your recovery phrases.
 
 <Admonition type="note">
-    Keycard and Keycard Shell work with a software wallet. If you use SLIP39, choose a [software wallet](https://keycard.tech/en/wallets) that supports both Keycard and SLIP39, such as Rabby, Sparrow, or BlueWallet.
+    Keycard and Keycard Shell work with a software wallet. If you use SLIP39, choose a [software wallet](https://docs.keycard.tech/en/wallets) that supports both Keycard and SLIP39, such as Rabby, Sparrow, or BlueWallet.
 </Admonition>
 
 ## SLIP39 FAQ

--- a/content/help/use-keycard-directly-with-a-software-wallet.mdx
+++ b/content/help/use-keycard-directly-with-a-software-wallet.mdx
@@ -5,7 +5,7 @@ title: Use Keycard directly with a software wallet
 
 # Use Keycard directly with a software wallet
 
-Keycard is a versatile smart card that works in multiple configurations. While you can use Keycard with Shell, you can also connect Keycard directly to a [compatible software wallet](https://keycard.tech/en/wallets) — either on mobile or desktop.
+Keycard is a versatile smart card that works in multiple configurations. While you can use Keycard with Shell, you can also connect Keycard directly to a [compatible software wallet](https://docs.keycard.tech/en/wallets) — either on mobile or desktop.
 
 ## Mobile Wallets
 

--- a/content/help/verify-keycard-shell-authenticity.mdx
+++ b/content/help/verify-keycard-shell-authenticity.mdx
@@ -32,7 +32,7 @@ In addition to your Keycard and Keycard Shell, you need a computer or mobile dev
 5. Scan the QR code on your Keycard Shell with the camera on your computer or mobile device.
 
 <Admonition type="note">
-   During verification, the Shell signs a one-time QR challenge and includes its device certificate. The verification service validates the signature and certificate, then returns the verification result and history. You then scan a final QR code with the Shell to confirm that the result is not altered by the browser. Check out [Keycard Shell verification: How you can proof your Shell is authentic ↗](https://keycard.tech/en/blog/keycard-shell-verification-what-verify-actually-proves-and-why-it-matters) to learn more.
+   During verification, the Shell signs a one-time QR challenge and includes its device certificate. The verification service validates the signature and certificate, then returns the verification result and history. You then scan a final QR code with the Shell to confirm that the result is not altered by the browser. Check out [Keycard Shell verification: How you can proof your Shell is authentic ↗](https://docs.keycard.tech/en/blog/keycard-shell-verification-what-verify-actually-proves-and-why-it-matters) to learn more.
 </Admonition>
 
 <Admonition type="caution">

--- a/src/app/(with-navigation)/start/keycard/page.tsx
+++ b/src/app/(with-navigation)/start/keycard/page.tsx
@@ -54,7 +54,7 @@ export default function StartKeycardPage() {
             </Link>{' '}
             for setup instructions, or browse the{' '}
             <a
-              href="https://keycard.tech/en/wallets"
+              href="https://docs.keycard.tech/en/wallets"
               className="text-white-95 underline underline-offset-2 hover:text-white-60"
               target="_blank"
               rel="noopener noreferrer"

--- a/src/app/[locale]/(with-navigation)/about/page.tsx
+++ b/src/app/[locale]/(with-navigation)/about/page.tsx
@@ -84,7 +84,7 @@ const PARTNERS = [
   },
   {
     name: 'Docs',
-    href: 'https://keycard.tech/en/developers/overview',
+    href: 'https://docs.keycard.tech/en/developers/overview',
   },
 ]
 

--- a/src/app/[locale]/(with-navigation)/blog/[slug]/page.tsx
+++ b/src/app/[locale]/(with-navigation)/blog/[slug]/page.tsx
@@ -95,7 +95,7 @@ export default async function BlogDetailPage(props: Props) {
 
   const author = post.primary_author!
   const tag = post.primary_tag
-  const articleUrl = `https://keycard.tech/${locale}/blog/${post.slug}`
+  const articleUrl = `https://docs.keycard.tech/${locale}/blog/${post.slug}`
   const structuredData = {
     '@context': 'https://schema.org',
     '@type': 'BlogPosting',

--- a/src/app/[locale]/(with-navigation)/help/[...slug]/page.tsx
+++ b/src/app/[locale]/(with-navigation)/help/[...slug]/page.tsx
@@ -128,7 +128,7 @@ const Page = async (props: Props) => {
   const breadcrumbs = generateBreadcrumbs((await params).slug, meta.title)
 
   const locale = await getLocale()
-  const articleUrl = `https://keycard.tech/${locale}/help/${(
+  const articleUrl = `https://docs.keycard.tech/${locale}/help/${(
     await params
   ).slug.join('/')}`
   const structuredData = {

--- a/src/app/[locale]/(with-navigation)/wallets/page.tsx
+++ b/src/app/[locale]/(with-navigation)/wallets/page.tsx
@@ -45,8 +45,8 @@ const WALLETS: Wallet[] = [
     type: ['Keycard'],
     blockchains: ['Ethereum'],
     platform: ['Mobile', 'Desktop'],
-    setupGuideUrl: 'https://keycard.tech/en/start/keycard',
-    websiteUrl: 'https://keycard.tech/en/start/keycard',
+    setupGuideUrl: 'https://docs.keycard.tech/en/start/keycard',
+    websiteUrl: 'https://docs.keycard.tech/en/start/keycard',
   },
   {
     name: 'Rabby',


### PR DESCRIPTION
## Summary
- Replace approved hardcoded `https://keycard.tech/...` links with `https://docs.keycard.tech/...` in help content and docs-facing pages.
- Update localized article URL templates for help and blog structured data to use the docs domain.
- Leave sitemap/base URL/shopify/OpenGraph and other "review carefully" domain references unchanged.

## Test plan
- [x] Confirm targeted old URL patterns no longer exist in codebase.
- [x] Verify lint passes for edited application files.
- [ ] Manually click-check updated links in help pages, wallets page, start page, about page, and a blog/help article page.
- [ ] Validate structured data `url` fields render with `docs.keycard.tech` for localized blog/help pages.