### PR TITLE
Migrate infrastructure and metadata URLs to docs.keycard.tech

### DIFF
--- a/assets/shared-cart.js
+++ b/assets/shared-cart.js
@@ -3,7 +3,7 @@ import { CartAddEvent } from '@theme/events'
 const CART_COOKIE_NAME = 'kc_cart_id'
 const CART_COOKIE_DOMAIN = '.keycard.tech'
 const CART_MAX_AGE_SECONDS = 60 * 60 * 24 * 30
-const PROXY_URL = 'https://keycard.tech/api/shopify/storefront'
+const PROXY_URL = 'https://docs.keycard.tech/api/shopify/storefront'
 
 const shouldUseSharedDomain = () =>
   typeof window !== 'undefined' &&

--- a/public/shopify-lang-sync.js
+++ b/public/shopify-lang-sync.js
@@ -1,7 +1,7 @@
 /**
  * Shopify storefront helper.
  * Usage: load on get.keycard.tech (e.g. theme.liquid)
- * <script src="https://keycard.tech/shopify-lang-sync.js" defer></script>
+ * <script src="https://docs.keycard.tech/shopify-lang-sync.js" defer></script>
  */
 (function syncShopifyLocaleToCookie() {
   const COOKIE_NAME = 'lang'

--- a/src/app/[locale]/(with-navigation)/(homepage)/_components/keycard-shell.tsx
+++ b/src/app/[locale]/(with-navigation)/(homepage)/_components/keycard-shell.tsx
@@ -90,7 +90,7 @@ const KeycardShell = () => {
           brand: { '@type': 'Brand', name: 'Keycard' },
           description:
             'A modular, air-gapped hardware wallet that uses Keycard as the secure element.',
-          image: ['https://keycard.tech/assets/keycard-shell.webp'],
+          image: ['https://docs.keycard.tech/assets/keycard-shell.webp'],
           sku: 'SHELL-001',
           offers: {
             '@type': 'Offer',

--- a/src/app/[locale]/(with-navigation)/(homepage)/_components/keycard.tsx
+++ b/src/app/[locale]/(with-navigation)/(homepage)/_components/keycard.tsx
@@ -71,7 +71,7 @@ const Keycard = () => {
           brand: { '@type': 'Brand', name: 'Keycard' },
           description:
             'A smart card with secure element for storing keys and transacting via NFC.',
-          image: ['https://keycard.tech/assets/keycard/card.png'],
+          image: ['https://docs.keycard.tech/assets/keycard/card.png'],
           sku: 'SKCR02',
           offers: {
             '@type': 'Offer',

--- a/src/app/[locale]/(with-navigation)/blog/[slug]/page.tsx
+++ b/src/app/[locale]/(with-navigation)/blog/[slug]/page.tsx
@@ -115,7 +115,7 @@ export default async function BlogDetailPage(props: Props) {
       name: 'Keycard',
       logo: {
         '@type': 'ImageObject',
-        url: 'https://keycard.tech/opengraph-image.png',
+        url: 'https://docs.keycard.tech/opengraph-image.png',
       },
     },
     mainEntityOfPage: articleUrl,

--- a/src/app/[locale]/(with-navigation)/blog/sitemap.xml/route.ts
+++ b/src/app/[locale]/(with-navigation)/blog/sitemap.xml/route.ts
@@ -1,3 +1,3 @@
 export async function GET() {
-  return Response.redirect('https://keycard.tech/sitemap.xml', 301)
+  return Response.redirect('https://docs.keycard.tech/sitemap.xml', 301)
 }

--- a/src/app/[locale]/(with-navigation)/help/[...slug]/page.tsx
+++ b/src/app/[locale]/(with-navigation)/help/[...slug]/page.tsx
@@ -145,7 +145,7 @@ const Page = async (props: Props) => {
       name: 'Keycard',
       logo: {
         '@type': 'ImageObject',
-        url: 'https://keycard.tech/opengraph-image.png',
+        url: 'https://docs.keycard.tech/opengraph-image.png',
       },
     },
     mainEntityOfPage: articleUrl,

--- a/src/app/_lib/sitemap-data.ts
+++ b/src/app/_lib/sitemap-data.ts
@@ -7,7 +7,7 @@ import type { MetadataRoute } from 'next'
 export const revalidate = 3600
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const base = 'https://keycard.tech'
+  const base = 'https://docs.keycard.tech'
   const now = new Date()
 
   const locales = [...SUPPORTED_LOCALES]

--- a/src/app/api/shopify/storefront/route.ts
+++ b/src/app/api/shopify/storefront/route.ts
@@ -4,6 +4,7 @@ export const dynamic = 'force-dynamic'
 
 const ALLOWED_ORIGINS = [
   'https://keycard.tech',
+  'https://docs.keycard.tech',
   'https://get.keycard.tech',
   'http://localhost:3000',
 ]

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ const inter = Inter({
 })
 
 export const metadata = Metadata({
-  metadataBase: new URL('https://keycard.tech/'),
+  metadataBase: new URL('https://docs.keycard.tech/'),
 
   title: {
     default: 'Keycard',
@@ -144,7 +144,7 @@ export default async function RootLayout({ children }: Props) {
           strategy="afterInteractive"
           src="https://umami.bi.status.im/script.js"
           data-website-id="a335ad8b-deef-4960-b565-3d4e21b7a8e5"
-          data-domains="keycard.tech"
+          data-domains="keycard.tech,docs.keycard.tech"
         />
       </body>
     </html>

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -4,9 +4,9 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: { userAgent: '*', allow: '/' },
     sitemap: [
-      'https://keycard.tech/sitemap.xml',
+      'https://docs.keycard.tech/sitemap.xml',
       'https://get.keycard.tech/sitemap.xml',
     ],
-    // host: 'https://keycard.tech', // optional
+    // host: 'https://docs.keycard.tech', // optional
   }
 }


### PR DESCRIPTION
## Summary
- Update `metadataBase`, sitemap base URL, `robots.txt` sitemap reference, and blog sitemap redirect to `docs.keycard.tech`.
- Update structured data publisher logo and Product JSON-LD image URLs to resolve on the serving host.
- Update Shopify cart proxy URL (`shared-cart.js`) and add `docs.keycard.tech` to CORS allowed origins to prevent cart breakage.
- Update `shopify-lang-sync.js` usage comment to reflect new host.
- Add `docs.keycard.tech` to Umami analytics `data-domains`.

## Intentionally unchanged
- Organization JSON-LD `url` stays `keycard.tech` (brand canonical).
- About page cert link stays `keycard.tech` (intentional product site reference).
- Shopify `storefrontRootDomain` stays `keycard.tech`.
- Shared cookie domains (`.keycard.tech`) unchanged (needed across subdomains).

## Test plan
- [ ] Verify sitemap at `docs.keycard.tech/sitemap.xml` lists correct `docs.keycard.tech` URLs.
- [ ] Check `<link rel="canonical">` on a help page and blog page points to `docs.keycard.tech`.
- [ ] Verify OG image URL resolves when sharing a blog/help article link.
- [ ] Test cart add-to-cart flow from `docs.keycard.tech` (CORS + proxy).
- [ ] Confirm Umami dashboard records pageviews from `docs.keycard.tech`.
- [ ] Validate Product rich results in Google Rich Results Test for homepage.