### PR TITLE
Replace product homepage with docs landing page

### DIFF
--- a/src/app/[locale]/(with-navigation)/(homepage)/page.tsx
+++ b/src/app/[locale]/(with-navigation)/(homepage)/page.tsx
@@ -1,13 +1,7 @@
 import { Metadata } from '~/app/_metadata'
 import { buildLocaleAlternates } from '~/app/_utils/metadata'
-import { TestimonialsStrip } from '~components/testimonials-strip'
-import { AutoOpenDialogManager } from './_components/auto-open-dialog-manager'
-import { BuyCards } from './_components/buy-cards-client'
-import { ComparisonTable } from './_components/comparison-table'
-import { Faqs } from './_components/faqs'
-import { Keycard } from './_components/keycard'
-import { KeycardFeatures } from './_components/keycard-features'
-import { KeycardShell } from './_components/keycard-shell'
+import { ButtonLink } from '~components/button-link'
+import { Logo } from '~components/logo'
 
 type MetadataProps = {
   params: Promise<{
@@ -19,26 +13,75 @@ export async function generateMetadata({ params }: MetadataProps) {
   const { locale } = await params
 
   return Metadata({
-    title: {
-      absolute: 'Keycard: Open-Source Air-Gapped Crypto Hardware Wallet',
-    },
+    title: 'Keycard Documentation',
     description:
-      'Secure your crypto with Keycard hardware. Air-gapped, contactless NFC, and open-source. Use Keycard Shell for modular cold storage and Keycard for everyday access.',
+      'Find help articles, setup guides, and developer documentation for Keycard and Keycard Shell.',
     alternates: buildLocaleAlternates(locale, '/'),
   })
 }
 
 export default function HomePage() {
   return (
-    <>
-      <AutoOpenDialogManager />
-      <KeycardShell />
-      <Keycard />
-      <TestimonialsStrip />
-      <KeycardFeatures />
-      <ComparisonTable />
-      <Faqs />
-      <BuyCards />
-    </>
+    <div className="flex min-h-[calc(100vh-200px)] flex-col items-center justify-center px-3 pb-[120px] pt-12 md:px-8">
+      <div className="w-full max-w-[720px]">
+        <div className="mb-12 text-center">
+          <Logo className="opacity-60 mx-auto mb-6 h-10 w-auto" />
+          <h1 className="font-lora text-32 font-400 text-white-95 lg:text-48">
+            Documentation
+          </h1>
+          <p className="text-18 mx-auto mt-3 max-w-[480px] font-inter font-300 text-white-60">
+            What are you looking for?
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-4 lg:flex-row">
+          <div className="flex flex-1 flex-col rounded-28 border border-white-8 bg-white-4 p-6 pt-5">
+            <p className="mb-1 text-14 font-400 uppercase tracking-wider text-orange">
+              User guides
+            </p>
+            <h2 className="mb-2 font-lora text-24 font-400 text-white-95">
+              I use Keycard or Shell
+            </h2>
+            <p className="mb-6 font-inter text-16 font-300 text-white-60">
+              Setup guides, wallet pairing, transaction signing,
+              troubleshooting, and FAQ.
+            </p>
+            <ButtonLink href="/help" variant="primary" className="mt-auto">
+              Help center
+            </ButtonLink>
+          </div>
+
+          <div className="flex flex-1 flex-col rounded-28 border border-white-8 bg-white-4 p-6 pt-5">
+            <p className="mb-1 text-14 font-400 uppercase tracking-wider text-orange">
+              Technical docs
+            </p>
+            <h2 className="mb-2 font-lora text-24 font-400 text-white-95">
+              I build with Keycard
+            </h2>
+            <p className="mb-6 font-inter text-16 font-300 text-white-60">
+              API reference, protocol details, firmware internals, and
+              integration guides.
+            </p>
+            <ButtonLink
+              href="/developers"
+              variant="primary"
+              className="mt-auto"
+            >
+              Developer docs
+            </ButtonLink>
+          </div>
+        </div>
+
+        <p className="mt-8 text-center font-inter text-14 font-300 text-white-40">
+          Looking for the product?{' '}
+          <a
+            href="https://keycard.tech"
+            className="text-white-60 underline underline-offset-2 hover:text-white-80"
+          >
+            keycard.tech
+          </a>
+        </p>
+      </div>
+    </div>
   )
 }

--- a/src/app/[locale]/(with-navigation)/(homepage)/page.tsx
+++ b/src/app/[locale]/(with-navigation)/(homepage)/page.tsx
@@ -56,7 +56,7 @@ export default function HomePage() {
               Technical docs
             </p>
             <h2 className="mb-2 font-lora text-24 font-400 text-white-95">
-              I build with Keycard
+              I build with Keycard and Shell
             </h2>
             <p className="mb-6 font-inter text-16 font-300 text-white-60">
               API reference, protocol details, firmware internals, and


### PR DESCRIPTION
## Summary
- Replace the full product homepage (hero sections, testimonials, comparison table, FAQs, buy cards) with a minimal docs landing page.
- Two clear paths: **Help center** (user guides) and **Developer docs** (technical reference).
- Subtle link to `keycard.tech` for users looking for the product site.
- Uses existing design system: `Logo` component, `ButtonLink`, Lora/Inter fonts, standard card styling.

## Test plan
- [ ] Visit `docs.keycard.tech/` and verify the new landing page renders correctly.
- [ ] Click "Help center" and verify it navigates to `/help`.
- [ ] Click "Developer docs" and verify it navigates to `/developers`.
- [ ] Click `keycard.tech` link at bottom and verify it opens the product site.
- [ ] Test responsive layout on mobile and desktop.