### PR TITLE
fix(nav): Header logo links to keycard.tech

### DIFF
--- a/src/app/_components/nav-bar-mobile/index.tsx
+++ b/src/app/_components/nav-bar-mobile/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { getRoutes, type Routes } from '~/config/routes'
+import { getRoutes, KEYCARD_TECH_URL, type Routes } from '~/config/routes'
 import { CartBadge } from '~components/cart/cart-badge'
 import { cx } from 'cva'
 import { AnimatePresence, motion, useScroll, useTransform } from 'framer-motion'
@@ -101,7 +101,12 @@ const NavBarMobile = () => {
       }}
     >
       <div className="flex items-center justify-between p-5">
-        <Link href="/" className="text-white-95" aria-label="Homepage">
+        <Link
+          href={KEYCARD_TECH_URL}
+          target="_self"
+          className="text-white-95"
+          aria-label="Homepage"
+        >
           <Logo className="h-10" />
         </Link>
         <div className="flex items-center gap-4">

--- a/src/app/_components/nav-bar.tsx
+++ b/src/app/_components/nav-bar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { getShopifyUrl } from '~/config/routes'
+import { getShopifyUrl, KEYCARD_TECH_URL } from '~/config/routes'
 import { CartBadge } from '~components/cart/cart-badge'
 import { cva } from 'cva'
 import {
@@ -101,7 +101,7 @@ const NavBar = () => {
         WebkitBackdropFilter: backdropFilter,
       }}
     >
-      <Link href="/" aria-label="Homepage">
+      <Link href={KEYCARD_TECH_URL} target="_self" aria-label="Homepage">
         <Logo />
       </Link>
 

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -3,6 +3,9 @@ import { useTranslations } from 'next-intl'
 
 const SHOPIFY_BASE_URL = 'https://get.keycard.tech'
 
+/** Primary marketing storefront (distinct from docs at docs.keycard.tech) */
+export const KEYCARD_TECH_URL = 'https://keycard.tech'
+
 const normalizeLocale = (locale: string): SupportedLocale =>
   SUPPORTED_LOCALES.includes(locale as SupportedLocale)
     ? (locale as SupportedLocale)
@@ -31,7 +34,7 @@ export const getRoutes = (
       },
       {
         name: t('footer.keycard.buy.translation'),
-        href: getShopifyUrl(locale, '/pages/keycard'),
+        href: getShopifyUrl(locale, '/products/keycard'),
       },
       {
         name: t('footer.keycard.get_started.translation'),
@@ -129,7 +132,7 @@ export const ROUTES = {
     },
     {
       name: 'Buy Keycard',
-      href: getShopifyUrl(defaultLocale, '/pages/keycard'),
+      href: getShopifyUrl(defaultLocale, '/products/keycard'),
     },
     {
       name: 'Get Started',


### PR DESCRIPTION
On docs.keycard.tech, the top-left logo previously stayed on the docs site (`/`). It should take users to the main marketing storefront.

- Introduce `KEYCARD_TECH_URL` in `routes.ts`.
- Use it for desktop and mobile nav logos (same tab via `target="_self"`).