### PR TITLE
Remove Walleth from wallets page

### DIFF
--- a/src/app/[locale]/(with-navigation)/wallets/page.tsx
+++ b/src/app/[locale]/(with-navigation)/wallets/page.tsx
@@ -148,15 +148,6 @@ const WALLETS: Wallet[] = [
     websiteUrl: 'https://wallet.bullbitcoin.com',
   },
   {
-    name: 'Walleth',
-    icon: { url: '/assets/wallets/walleth.png', width: 96, height: 81 },
-    type: ['Keycard'],
-    blockchains: ['Ethereum'],
-    platform: ['Mobile'],
-    setupGuideUrl: '/help/connect-keycard-shell-to-a-software-wallet',
-    websiteUrl: 'https://walleth.org',
-  },
-  {
     name: 'Ambire',
     icon: { url: '/assets/wallets/ambire.svg', width: 100, height: 100 },
     type: ['Shell'],


### PR DESCRIPTION
## Summary
- Remove the Walleth wallet card from the wallets compatibility list.
- Keep the wallets page aligned with currently supported integrations on docs.keycard.tech/en/wallets.

## Test plan
- [x] Verify `Walleth` is removed from `src/app/[locale]/(with-navigation)/wallets/page.tsx`.
- [x] Run pre-commit checks (eslint/prettier via hooks).
- [ ] Open the wallets page locally and confirm Walleth no longer appears in the grid.