### PR TITLE
docs(help): update MetaMask Shell connection note

### DIFF
--- a/content/help/connect-keycard-shell-to-metamask.mdx
+++ b/content/help/connect-keycard-shell-to-metamask.mdx
@@ -10,7 +10,7 @@ title: Connect Keycard Shell to MetaMask
 You can use your Keycard Shell with MetaMask to manage crypto assets, interact with dApps, and access all available MetaMask features.
 
 <Admonition type="note">
-    To connect Keycard Shell to MetaMask, go to **Add wallet** then **Connect a hardware wallet** and choose **QR-based**.
+    To connect Keycard Shell to MetaMask, choose **Add wallet**, then **Connect a hardware wallet**, then **QR-based**.
 </Admonition>
 
 ## What to expect
@@ -25,12 +25,12 @@ In this process, you use MetaMask on your phone or browser to scan a QR code dis
 
 ### Step 1: Prepare the MetaMask app
 
-Metamask requires you to create a new wallet account or import your existing wallet before connecting Keycard Shell even if you if you don't plan to use it. This wallet is separate from your Keycard and Keycard Shell.
+MetaMask requires you to create a new wallet account or import your existing wallet before connecting Keycard Shell even if you if you don't plan to use it. This wallet is separate from your Keycard and Keycard Shell.
 
 1. Open the MetaMask app on your browser or smartphone.
 1. If this is your first time using MetaMask, create a new wallet account or import an existing one using your recovery phrase.
 1. On top of the screen, click **Expand ⌵** next to your wallet account name. By default, the name is **Account 1**.
-1. Select **Add wallet** > **Add a hardware wallet**.
+1. Select **Add wallet** > **Connect a hardware wallet**.
 1. Select **QR-based**.
 1. Scroll down and select **Continue**.
 

--- a/content/help/connect-keycard-shell-to-metamask.mdx
+++ b/content/help/connect-keycard-shell-to-metamask.mdx
@@ -10,7 +10,7 @@ title: Connect Keycard Shell to MetaMask
 You can use your Keycard Shell with MetaMask to manage crypto assets, interact with dApps, and access all available MetaMask features.
 
 <Admonition type="note">
-    Currently, Keycard Shell doesn't appear on MetaMask's list of supported hardware wallets, but you can still connect it to MetaMask by selecting the **QR-based** option.
+    To connect Keycard Shell to MetaMask, go to **Add wallet** then **Connect a hardware wallet** and choose **QR-based**.
 </Admonition>
 
 ## What to expect


### PR DESCRIPTION
Updates the callout on the Connect Keycard Shell to MetaMask help page to describe the in-app path (**Add wallet** → **Connect a hardware wallet** → **QR-based**) instead of referring to MetaMask’s hardware wallet list.

Also aligns Step 1 with the same menu labels and fixes MetaMask brand casing in the Step 1 intro paragraph.