### PR TITLE
Add YouTube link to footer Contacts section

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -874,6 +874,10 @@
       "x": {
         "translation": "X",
         "notes": "footer::contacts::x"
+      },
+      "youtube": {
+        "translation": "YouTube",
+        "notes": "footer::contacts::youtube"
       }
     },
     "legal": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -874,6 +874,10 @@
       "x": {
         "translation": "X",
         "notes": "footer::contacts::x"
+      },
+      "youtube": {
+        "translation": "YouTube",
+        "notes": "footer::contacts::youtube"
       }
     },
     "legal": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -874,6 +874,10 @@
       "x": {
         "translation": "X",
         "notes": "footer::contacts::x"
+      },
+      "youtube": {
+        "translation": "YouTube",
+        "notes": "footer::contacts::youtube"
       }
     },
     "legal": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -874,6 +874,10 @@
       "x": {
         "translation": "X",
         "notes": "footer::contacts::x"
+      },
+      "youtube": {
+        "translation": "YouTube",
+        "notes": "footer::contacts::youtube"
       }
     },
     "legal": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -856,6 +856,10 @@
       "x": {
         "translation": "X",
         "notes": "footer::contacts::x"
+      },
+      "youtube": {
+        "translation": "YouTube",
+        "notes": "footer::contacts::youtube"
       }
     },
     "legal": {

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -874,6 +874,10 @@
       "x": {
         "translation": "X",
         "notes": "footer::contacts::x"
+      },
+      "youtube": {
+        "translation": "YouTube",
+        "notes": "footer::contacts::youtube"
       }
     },
     "legal": {

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -94,6 +94,10 @@ export const getRoutes = (
         name: t('footer.contacts.x.translation'),
         href: 'https://x.com/Keycard_',
       },
+      {
+        name: t('footer.contacts.youtube.translation'),
+        href: 'https://www.youtube.com/@Keycard_tech/',
+      },
       // { name: 'Email', href: 'mailto:support@keycard.tech' },
     ],
     Legal: [
@@ -201,6 +205,11 @@ export const ROUTES = {
     {
       name: 'X',
       href: 'https://x.com/Keycard_',
+      external: true,
+    },
+    {
+      name: 'YouTube',
+      href: 'https://www.youtube.com/@Keycard_tech/',
       external: true,
     },
   ],


### PR DESCRIPTION
## Summary
- Add a YouTube link in the footer Contacts column, below X
- Point to https://www.youtube.com/@Keycard_tech/
- Add i18n labels across all supported locales

## Test plan
- [ ] Open any page and confirm YouTube appears under X in the footer Contacts section
- [ ] Confirm the link opens https://www.youtube.com/@Keycard_tech/ in a new tab
- [ ] Spot-check footer in a non-English locale (e.g. fr, de)