### PR TITLE
Fix stored XSS in JSON-LD and Ghost HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-dom": "19.0.1",
     "react-error-boundary": "^5.0.0",
     "react-hook-form": "^7.53.1",
+    "rehype-sanitize": "^6.0.0",
     "server-only": "^0.0.1",
     "three": "^0.170.0",
     "three-stdlib": "^2.34.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       react-hook-form:
         specifier: ^7.53.1
         version: 7.53.2(react@19.0.1)
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -2465,6 +2468,9 @@ packages:
   hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
 
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-estree@3.1.0:
     resolution: {integrity: sha512-lfX5g6hqVh9kjS/B9E2gSkvHH4SZNiQFiqWS0x9fENzEl+8W12RqdRxX6d/Cwxi30tPQs3bIO+aolQJNp1bIyw==}
 
@@ -3493,6 +3499,9 @@ packages:
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   rehype-slug@6.0.0:
     resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
@@ -6506,6 +6515,12 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.2.0
+      unist-util-position: 5.0.0
+
   hast-util-to-estree@3.1.0:
     dependencies:
       '@types/estree': 1.0.6
@@ -7739,6 +7754,11 @@ snapshots:
       hast-util-to-estree: 3.1.0
     transitivePeerDependencies:
       - supports-color
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
 
   rehype-slug@6.0.0:
     dependencies:

--- a/scripts/test-json-ld-serialize.mjs
+++ b/scripts/test-json-ld-serialize.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+
+/** Keep in sync with src/app/_components/json-ld.tsx */
+function serializeJsonLd(data) {
+  return JSON.stringify(data).replace(/</g, '\\u003c')
+}
+
+const payload = {
+  headline:
+    '</script><script>window.__jsonld_xss=1;document.body.setAttribute("data-pwned","jsonld")</script>',
+}
+
+const serialized = serializeJsonLd(payload)
+
+assert.doesNotMatch(
+  serialized,
+  /<\/script>/i,
+  'serialized JSON-LD must not contain </script>',
+)
+assert.ok(
+  serialized.includes('\\u003c'),
+  'angle brackets must be unicode-escaped',
+)
+
+const parsed = JSON.parse(serialized)
+assert.equal(
+  parsed.headline,
+  payload.headline,
+  'JSON-LD content must round-trip after parsing',
+)
+
+console.log('serializeJsonLd: ok')

--- a/src/app/[locale]/(with-navigation)/about/page.tsx
+++ b/src/app/[locale]/(with-navigation)/about/page.tsx
@@ -1,3 +1,4 @@
+import { JsonLd } from '~/app/_components/json-ld'
 import { Metadata } from '~/app/_metadata'
 import {
   buildLocaleAlternates,
@@ -106,38 +107,33 @@ const STANDARDS = [
 export default async function AboutPage() {
   const t = await getTranslations()
 
+  const organizationStructuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: 'Keycard',
+    url: 'https://keycard.tech',
+    parentOrganization: {
+      '@type': 'Organization',
+      name: 'Institute of Free Technology',
+      url: 'https://free.technology',
+    },
+    sameAs: [
+      'https://status.app/keycard',
+      'https://github.com/keycard-tech',
+      'https://x.com/keycard_',
+    ],
+    contactPoint: [
+      {
+        '@type': 'ContactPoint',
+        contactType: 'partnerships',
+        email: 'get@keycard.tech',
+      },
+    ],
+  }
+
   return (
     <div className="px-3 pb-[120px] pt-12 md:px-8 lg:px-20 lg:pt-20">
-      {/* Organization JSON-LD for trust signals */}
-      <script
-        type="application/ld+json"
-        // Note: avoid user PII here; this is org-level structured data.
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify({
-            '@context': 'https://schema.org',
-            '@type': 'Organization',
-            name: 'Keycard',
-            url: 'https://keycard.tech',
-            parentOrganization: {
-              '@type': 'Organization',
-              name: 'Institute of Free Technology',
-              url: 'https://free.technology',
-            },
-            sameAs: [
-              'https://status.app/keycard',
-              'https://github.com/keycard-tech',
-              'https://x.com/keycard_',
-            ],
-            contactPoint: [
-              {
-                '@type': 'ContactPoint',
-                contactType: 'partnerships',
-                email: 'get@keycard.tech',
-              },
-            ],
-          }),
-        }}
-      />
+      <JsonLd data={organizationStructuredData} />
 
       <header className="mb-8 grid gap-3">
         <h1 className="font-lora text-32 font-500 text-white-95 xl:text-48">

--- a/src/app/[locale]/(with-navigation)/blog/[slug]/page.tsx
+++ b/src/app/[locale]/(with-navigation)/blog/[slug]/page.tsx
@@ -1,6 +1,7 @@
-import { baseComponents } from '~/app/_components/content'
 import { Breadcrumbs } from '~/app/_components/docs/breadcrumbs'
+import { JsonLd } from '~/app/_components/json-ld'
 import { getPostBySlug, getPostSlugs } from '~/app/_lib/ghost'
+import { renderGhostHtml } from '~/app/_lib/ghost/render-html'
 import { Metadata } from '~/app/_metadata'
 import { formatDate } from '~/app/_utils/format-date'
 import {
@@ -12,10 +13,6 @@ import { SUPPORTED_LOCALES } from '~/i18n/constants'
 import { Image } from '~components/image'
 import { getLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
-import { createElement, Fragment } from 'react'
-import rehypeParse from 'rehype-parse'
-import rehypeReact from 'rehype-react'
-import { unified } from 'unified'
 import { PostAuthor } from '../_components/post-author'
 import { PostTag } from '../_components/post-tag'
 
@@ -65,14 +62,7 @@ export default async function BlogDetailPage(props: Props) {
   }
 
   const locale = await getLocale()
-  const { result } = await unified()
-    .use(rehypeParse, { fragment: true })
-    .use(rehypeReact, {
-      createElement,
-      Fragment,
-      components: baseComponents,
-    })
-    .process(post.html!)
+  const result = await renderGhostHtml(post.html!)
 
   // root
   const breadcrumbs = [
@@ -125,12 +115,7 @@ export default async function BlogDetailPage(props: Props) {
   return (
     <>
       <Breadcrumbs items={breadcrumbs} />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify(structuredData),
-        }}
-      />
+      <JsonLd data={structuredData} />
       <div className="m-auto max-w-[664px] px-5 py-8 xl:py-12">
         <div className="gap-3">
           {tag && <PostTag size="32" tag={tag} />}

--- a/src/app/[locale]/(with-navigation)/help/[...slug]/page.tsx
+++ b/src/app/[locale]/(with-navigation)/help/[...slug]/page.tsx
@@ -2,6 +2,7 @@ import fs from 'fs/promises'
 import path from 'path'
 import { Breadcrumbs } from '~/app/_components/docs/breadcrumbs'
 import { DocsNavDrawer } from '~/app/_components/docs/docs-nav-drawer'
+import { JsonLd } from '~/app/_components/json-ld'
 import { Metadata } from '~/app/_metadata'
 import { formatDate } from '~/app/_utils/format-date'
 import { buildLocaleAlternates } from '~/app/_utils/metadata'
@@ -168,12 +169,7 @@ const Page = async (props: Props) => {
           />
         }
       />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify(structuredData),
-        }}
-      />
+      <JsonLd data={structuredData} />
       <div className="flex flex-1 justify-center gap-[139px] px-5 py-20 lg:pl-[250px] xl:pr-[140px]">
         <div className="w-full max-w-[664px]">
           <div className="mb-1 text-16 font-300 text-white-80">

--- a/src/app/_components/json-ld.tsx
+++ b/src/app/_components/json-ld.tsx
@@ -1,8 +1,13 @@
+/** Escape `<` so untrusted strings cannot break out of a JSON-LD script tag. */
+export function serializeJsonLd(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, '\\u003c')
+}
+
 export function JsonLd({ data }: { data: unknown }) {
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+      dangerouslySetInnerHTML={{ __html: serializeJsonLd(data) }}
     />
   )
 }

--- a/src/app/_lib/ghost/render-html.tsx
+++ b/src/app/_lib/ghost/render-html.tsx
@@ -1,0 +1,37 @@
+import { baseComponents } from '~/app/_components/content'
+import { createElement, Fragment } from 'react'
+import rehypeParse from 'rehype-parse'
+import rehypeReact from 'rehype-react'
+import rehypeSanitize, { defaultSchema, type Options } from 'rehype-sanitize'
+import { unified } from 'unified'
+
+const ghostHtmlSchema = {
+  ...defaultSchema,
+  tagNames: [...(defaultSchema.tagNames ?? []), 'iframe', 'figcaption'],
+  attributes: {
+    ...defaultSchema.attributes,
+    iframe: [
+      ['src', /^https:\/\//],
+      'width',
+      'height',
+      'title',
+      'allow',
+      'allowFullScreen',
+      'frameBorder',
+    ],
+  },
+} satisfies Options
+
+export async function renderGhostHtml(html: string) {
+  const { result } = await unified()
+    .use(rehypeParse, { fragment: true })
+    .use(rehypeSanitize, ghostHtmlSchema)
+    .use(rehypeReact, {
+      createElement,
+      Fragment,
+      components: baseComponents,
+    })
+    .process(html)
+
+  return result
+}


### PR DESCRIPTION
## Summary
- Escape `<` characters when serializing JSON-LD so untrusted CMS strings cannot break out of `<script type="application/ld+json">` blocks.
- Route all structured-data output through the shared `JsonLd` component (blog, help, about, and existing homepage usages).
- Sanitize Ghost blog HTML with `rehype-sanitize` before rendering, blocking script tags and event handlers while keeping HTTPS iframe embeds.

## Test plan
- [x] `node scripts/test-json-ld-serialize.mjs` — confirms `</script>` payloads are escaped
- [x] `pnpm check`
- [x] `pnpm lint`
- [ ] Deploy preview and spot-check a blog post with embeds still renders correctly
- [ ] View page source on a blog post and confirm JSON-LD contains `\u003c` instead of raw `<` when applicable