### PR TITLE
Include Ethereum in address browsing steps

### DIFF
--- a/content/help/verify-your-keycards-seed-and-addresses.mdx
+++ b/content/help/verify-your-keycards-seed-and-addresses.mdx
@@ -33,7 +33,7 @@ For a definitive check, you can enter your recovery phrase and Shell will confir
 To verify that a specific address belongs to your Keycard, you can browse all derived addresses directly on Shell's trusted screen and compare with what your software wallet displays.
 
 1. Insert your Keycard and enter your PIN.
-2. Go to **Addresses** > **Bitcoin**.
+2. Go to **Addresses** > **Bitcoin** or **Addresses** > **Ethereum**.
 3. Use ◀ / ▶ **Left** / **Right** to move through addresses one index at a time.
 4. To jump to a specific index, press the **orange key**, type the index number, and confirm.
 


### PR DESCRIPTION
## Summary

- Adds Ethereum as an option alongside Bitcoin in the "Browse your addresses" section of the verify seed article
- This was missed in #254

## Test plan

- [ ] Verify step 2 reads "Addresses > Bitcoin or Addresses > Ethereum"

🤖 Generated with [Claude Code](https://claude.com/claude-code)