### PR TITLE
docs: ask for JavaCard 3.0.5+ cards, not 3.0.4+

### DIFF
--- a/content/developers/build.mdx
+++ b/content/developers/build.mdx
@@ -17,7 +17,7 @@ Compiling and installing from source is probably the best way to proceed, since 
 
 - Linux, Windows or Mac computer
 - OpenJDK 11 (this specific version is required — newer JDKs are not compatible with the JavaCard build tools)
-- A Javacard 3.0.5+ smartcard with T=1 and SCP02 support. Cards of the JCOP4 family are known to work well. We ask for 3.0.5+ because the applet requires the `ALG_EC_SVDP_DH_PLAIN_XY` key agreement at installation time; some 3.0.4 cards implement it anyway and will also work.
+- A Javacard 3.0.5+ smartcard with T=1 and SCP02 support. Cards of the JCOP4 family are known to work well. We sell and ship this type of keycards for developers on [our shop](https://keycard.tech/products/keycard-for-developers). For detailed requirements about the card, we recommend to check this[readme.me](https://.com/keycard-tech/status-keycard/blob/master/README.md#what-kind-of-smartcards-can-i-use) in keycard github repository.
 - A standard PCSC smartcard reader
 
 ### Setting up OpenJDK 11

--- a/content/developers/build.mdx
+++ b/content/developers/build.mdx
@@ -5,7 +5,7 @@ title: Build Your Own Keycard
 
 # Build Your Own Keycard
 
-If you have a blank JavaCard 3.0.4+ card (readily available for purchase on the web) you can build your own Keycard. This is especially useful for developers who want to contribute to the project and/or experiment with it.
+If you have a blank JavaCard 3.0.5+ card (readily available for purchase on the web) you can build your own Keycard. This is especially useful for developers who want to contribute to the project and/or experiment with it.
 
 Please note that cards built this way will miss the certificate that is present on cards we distribute. This doesn't affect functionality in any way but will cause a warning to appear when using the card with Shell or another Keycard compatible wallet for the first time. Since you built the card yourself you can safely dismiss this warning.
 
@@ -17,7 +17,7 @@ Compiling and installing from source is probably the best way to proceed, since 
 
 - Linux, Windows or Mac computer
 - OpenJDK 11 (this specific version is required — newer JDKs are not compatible with the JavaCard build tools)
-- A Javacard 3.0.4+ smartcard with T=1 and SCP02 support. Cards of the JCOP4 family are known to work well. JavaCard 3.0.5 is recommended for best compatibility.
+- A Javacard 3.0.5+ smartcard with T=1 and SCP02 support. Cards of the JCOP4 family are known to work well. We ask for 3.0.5+ because the applet requires the `ALG_EC_SVDP_DH_PLAIN_XY` key agreement at installation time; some 3.0.4 cards implement it anyway and will also work.
 - A standard PCSC smartcard reader
 
 ### Setting up OpenJDK 11

--- a/content/developers/diy-keycard-shell.mdx
+++ b/content/developers/diy-keycard-shell.mdx
@@ -13,7 +13,7 @@ Keycard Shell is fully open source. You can build your own device, run your own 
 
 ## Build overview
 
-1. **Build or install the Keycard applet.** Start with [Build Your Own Keycard](/developers/build) and install the applet on a JavaCard 3.0.4+ card (3.0.5 recommended).
+1. **Build or install the Keycard applet.** Start with [Build Your Own Keycard](/developers/build) and install the applet on a JavaCard 3.0.5+ card.
 2. **Build the Shell hardware.** Use the open-source schematics, PCB files, and mechanical designs from the Keycard Shell repo.
 3. **Build and sign firmware.** Compile the firmware with STM32CubeIDE and sign it with your own bootloader key. Use the create-image tooling to generate a flashable image.
 4. **(Optional) Build a custom database.** Generate a clear-signing database that matches your supported chains and ABIs.


### PR DESCRIPTION
The Keycard applet requires `KeyAgreement.ALG_EC_SVDP_DH_PLAIN_XY` — a JavaCard **3.0.5** algorithm — unconditionally in the `SECP256k1` constructor, which runs at installation time with no fallback. So 3.0.5 is the real floor, not a recommendation.

Two pages presented it the other way round:

- `developers/build.mdx` — "a blank JavaCard 3.0.4+ card" / "A Javacard 3.0.4+ smartcard … JavaCard 3.0.5 is recommended for best compatibility"
- `developers/diy-keycard-shell.mdx` — "a JavaCard 3.0.4+ card (3.0.5 recommended)"

Both now ask for 3.0.5+, with one clause on the build page saying why and keeping the honest caveat that some 3.0.4 cards implement the algorithm and work fine.

`developers/hardware-specification` and `developers/getting-started` already defer to the status-keycard README rather than hardcoding a version, so they need no change here — the README itself is corrected in keycard-tech/status-keycard#123.

Not covered by this PR: two blog posts on the site still say 3.0.4, but they live in the CMS, not this repo — `announcing-keycard-shell` ("can be JavaCard 3.0.4 (or later)") and `keycard-our-key-to-contactless-crypto-adoption-2` ("based on the Java Card version 3.0.4+").

🤖 Generated with [Claude Code](https://claude.com/claude-code)