### PR TITLE
Make wallets page filters URL-driven and shareable

### DIFF
--- a/src/app/[locale]/(with-navigation)/wallets/page.tsx
+++ b/src/app/[locale]/(with-navigation)/wallets/page.tsx
@@ -6,7 +6,8 @@ import { KeycardShellIcon } from '~/app/_icons/keycard-shell-icon'
 import { ButtonLink } from '~components/button-link'
 import { Link } from '~components/link'
 import Image from 'next/image'
-import { useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { Suspense } from 'react'
 import { match } from 'ts-pattern'
 import { BuyCards } from '../(homepage)/_components/buy-cards-client'
 import { Tabs, TabsList, TabsTrigger } from './_components/tabs'
@@ -283,14 +284,40 @@ function WalletCard({ wallet }: { wallet: Wallet }) {
   )
 }
 
-export default function WalletsPage() {
-  const [activeHardware, setActiveHardware] = useState<'All' | WalletType>(
-    'All',
+const PLATFORMS: PlatformType[] = ['Mobile', 'Desktop', 'Extension']
+const ASSETS: BlockchainType[] = ['Bitcoin', 'Ethereum']
+const HARDWARE: WalletType[] = ['Keycard', 'Shell']
+
+// Read a query-string value case-insensitively and map it back to its
+// canonical filter label, falling back to 'All' for missing/unknown values.
+function parseFilter<T extends string>(
+  raw: string | null,
+  allowed: readonly T[],
+): 'All' | T {
+  if (!raw) return 'All'
+  return (
+    allowed.find(value => value.toLowerCase() === raw.toLowerCase()) ?? 'All'
   )
-  const [activePlatform, setActivePlatform] = useState<'All' | PlatformType>(
-    'All',
-  )
-  const [activeAsset, setActiveAsset] = useState<'All' | BlockchainType>('All')
+}
+
+function WalletsContent() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const pathname = usePathname()
+
+  const activePlatform = parseFilter(searchParams.get('platform'), PLATFORMS)
+  const activeAsset = parseFilter(searchParams.get('asset'), ASSETS)
+  const activeHardware = parseFilter(searchParams.get('hardware'), HARDWARE)
+
+  // Reflect a filter change in the URL so the selection is shareable and
+  // survives a reload. 'All' is the default, so it drops the param entirely.
+  const setFilter = (key: 'platform' | 'asset' | 'hardware', value: string) => {
+    const params = new URLSearchParams(searchParams.toString())
+    if (value === 'All') params.delete(key)
+    else params.set(key, value.toLowerCase())
+    const query = params.toString()
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false })
+  }
 
   const filteredWallets = WALLETS.filter(wallet => {
     if (activeHardware !== 'All' && !wallet.type.includes(activeHardware))
@@ -335,10 +362,8 @@ export default function WalletsPage() {
             By platform
           </span>
           <Tabs
-            defaultValue="All"
-            onValueChange={value =>
-              setActivePlatform(value as 'All' | PlatformType)
-            }
+            value={activePlatform}
+            onValueChange={value => setFilter('platform', value)}
           >
             <TabsList>
               <TabsTrigger value="All">All</TabsTrigger>
@@ -354,10 +379,8 @@ export default function WalletsPage() {
             By assets
           </span>
           <Tabs
-            defaultValue="All"
-            onValueChange={value =>
-              setActiveAsset(value as 'All' | BlockchainType)
-            }
+            value={activeAsset}
+            onValueChange={value => setFilter('asset', value)}
           >
             <TabsList>
               <TabsTrigger value="All">All</TabsTrigger>
@@ -372,10 +395,8 @@ export default function WalletsPage() {
             Integrates with
           </span>
           <Tabs
-            defaultValue="All"
-            onValueChange={value =>
-              setActiveHardware(value as 'All' | WalletType)
-            }
+            value={activeHardware}
+            onValueChange={value => setFilter('hardware', value)}
           >
             <TabsList>
               <TabsTrigger value="All">All</TabsTrigger>
@@ -432,5 +453,13 @@ export default function WalletsPage() {
 
       <BuyCards />
     </div>
+  )
+}
+
+export default function WalletsPage() {
+  return (
+    <Suspense>
+      <WalletsContent />
+    </Suspense>
   )
 }


### PR DESCRIPTION
## What

The **platform / asset / hardware** filters on `/en/wallets` now live in the URL query string instead of local component state. A filtered view can be linked, bookmarked, and survives a reload.

Tabs stay in sync both ways:
- Opening a filtered URL highlights the matching tabs and pre-filters the grid.
- Clicking a tab updates the URL while preserving the other two filters.
- Selecting **All** drops the param, keeping URLs clean (no `?asset=all`).

## URL scheme

Three optional, case-insensitive params, any combination:

| Param | Values |
|---|---|
| `platform` | `mobile` · `desktop` · `extension` |
| `asset` | `bitcoin` · `ethereum` |
| `hardware` | `keycard` · `shell` |

Example: `/en/wallets?asset=bitcoin&platform=mobile&hardware=shell`

## Notes

- `useSearchParams` requires a `Suspense` boundary; the page export now wraps the content in one.
- `tsc --noEmit` passes; verified both deep-link read and tab-click write in the dev server with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)